### PR TITLE
#91 #[derive(Lang)] を付与していた構造体が warning となる事象に対処

### DIFF
--- a/crates/ir_derive/tests/builder.rs
+++ b/crates/ir_derive/tests/builder.rs
@@ -8,6 +8,7 @@ use copager_lex_regex::RegexLexer;
 use copager_parse_lr_lalr1::LALR1;
 use copager_ir::{IR, IRBuilder, RawIR};
 
+#[allow(dead_code)]
 #[derive(Lang)]
 struct TestLang (
     #[tokenset] TestToken,

--- a/crates/ir_sexp/tests/simple.rs
+++ b/crates/ir_sexp/tests/simple.rs
@@ -6,6 +6,7 @@ use copager_lex_regex::RegexLexer;
 use copager_parse_lr_lr1::LR1;
 use copager_ir_sexp::{SExp, SExpOwned};
 
+#[allow(dead_code)]
 #[derive(Lang)]
 struct TestLang (
     #[tokenset] TestToken,

--- a/crates/ir_tree/src/owned/walker.rs
+++ b/crates/ir_tree/src/owned/walker.rs
@@ -111,6 +111,7 @@ mod tests {
 
     use super::{CSTreeOwned, CSTreeOwnedWalker};
 
+    #[allow(dead_code)]
     #[derive(Lang)]
     struct TestLang (
         #[tokenset] TestToken,

--- a/crates/ir_tree/src/ref/walker.rs
+++ b/crates/ir_tree/src/ref/walker.rs
@@ -111,6 +111,7 @@ mod tests {
 
     use super::{CSTree, CSTreeWalker};
 
+    #[allow(dead_code)]
     #[derive(Lang)]
     struct TestLang (
         #[tokenset] TestToken,

--- a/crates/ir_tree/tests/simple.rs
+++ b/crates/ir_tree/tests/simple.rs
@@ -7,6 +7,7 @@ use copager_parse_lr_lr1::LR1;
 use copager_ir_tree::r#ref::CSTree;
 use copager_ir_tree::owned::CSTreeOwned;
 
+#[allow(dead_code)]
 #[derive(Lang)]
 struct TestLang (
     #[tokenset] TestToken,

--- a/crates/lex_regex/tests/simple.rs
+++ b/crates/lex_regex/tests/simple.rs
@@ -4,6 +4,7 @@ use copager_lang::Lang;
 use copager_lex::BaseLexer;
 use copager_lex_regex::RegexLexer;
 
+#[allow(dead_code)]
 #[derive(Lang)]
 struct TestLang (
     #[tokenset] TestToken,

--- a/crates/lex_regex/tests/with_pp_trivia.rs
+++ b/crates/lex_regex/tests/with_pp_trivia.rs
@@ -4,6 +4,7 @@ use copager_lang::Lang;
 use copager_lex::BaseLexer;
 use copager_lex_regex::RegexLexer;
 
+#[allow(dead_code)]
 #[derive(Lang)]
 struct TestLang (
     #[tokenset] TestToken,

--- a/crates/lex_regex/tests/with_trivia.rs
+++ b/crates/lex_regex/tests/with_trivia.rs
@@ -4,6 +4,7 @@ use copager_lang::Lang;
 use copager_lex::BaseLexer;
 use copager_lex_regex::RegexLexer;
 
+#[allow(dead_code)]
 #[derive(Lang)]
 struct TestLang (
     #[tokenset] TestToken,

--- a/crates/parse_lr_lalr1/tests/simple.rs
+++ b/crates/parse_lr_lalr1/tests/simple.rs
@@ -6,6 +6,7 @@ use copager_lex_regex::RegexLexer;
 use copager_parse_lr_lalr1::LALR1;
 use copager_ir_void::Void;
 
+#[allow(dead_code)]
 #[derive(Lang)]
 struct TestLang (
     #[tokenset] TestToken,

--- a/crates/parse_lr_lr0/tests/simple.rs
+++ b/crates/parse_lr_lr0/tests/simple.rs
@@ -6,6 +6,7 @@ use copager_lex_regex::RegexLexer;
 use copager_parse_lr_lr0::LR0;
 use copager_ir_void::Void;
 
+#[allow(dead_code)]
 #[derive(Lang)]
 struct TestLang (
     #[tokenset] TestToken,

--- a/crates/parse_lr_lr1/tests/simple.rs
+++ b/crates/parse_lr_lr1/tests/simple.rs
@@ -6,6 +6,7 @@ use copager_lex_regex::RegexLexer;
 use copager_parse_lr_lr1::LR1;
 use copager_ir_void::Void;
 
+#[allow(dead_code)]
 #[derive(Lang)]
 struct TestLang (
     #[tokenset] TestToken,

--- a/crates/parse_lr_slr1/tests/simple.rs
+++ b/crates/parse_lr_slr1/tests/simple.rs
@@ -6,6 +6,7 @@ use copager_lex_regex::RegexLexer;
 use copager_parse_lr_slr1::SLR1;
 use copager_ir_void::Void;
 
+#[allow(dead_code)]
 #[derive(Lang)]
 struct TestLang (
     #[tokenset] TestToken,

--- a/examples/build_oneshot/src/main.rs
+++ b/examples/build_oneshot/src/main.rs
@@ -6,6 +6,7 @@ use copager::template::LALR1;
 use copager::prelude::*;
 use copager::Processor;
 
+#[allow(dead_code)]
 #[derive(Lang)]
 struct Arithmetic (
     #[tokenset] ArithmeticToken,

--- a/examples/build_prebuild/language/src/lib.rs
+++ b/examples/build_prebuild/language/src/lib.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use copager::lang::{Lang, TokenSet, RuleSet};
 use copager::prelude::*;
 
+#[allow(dead_code)]
 #[derive(Lang, Serialize, Deserialize)]
 pub struct Arithmetic (
     #[tokenset] ArithmeticToken,

--- a/examples/lang_easyarith/src/syntax.rs
+++ b/examples/lang_easyarith/src/syntax.rs
@@ -1,6 +1,7 @@
 use copager::lang::{Lang, RuleSet, TokenSet};
 use copager::prelude::*;
 
+#[allow(dead_code)]
 #[derive(Debug, Lang)]
 pub struct EasyArith (
     #[tokenset] EAToken,

--- a/examples/lang_json/src/syntax.rs
+++ b/examples/lang_json/src/syntax.rs
@@ -1,6 +1,7 @@
 use copager::lang::{Lang, RuleSet, TokenSet};
 use copager::prelude::*;
 
+#[allow(dead_code)]
 #[derive(Lang)]
 pub struct Json (
     #[tokenset] JsonToken,

--- a/examples/lang_pl0/src/syntax.rs
+++ b/examples/lang_pl0/src/syntax.rs
@@ -1,7 +1,7 @@
 use copager::lang::{Lang, TokenSet, RuleSet};
-use copager::template::LALR1;
 use copager::prelude::*;
 
+#[allow(dead_code)]
 #[derive(Lang)]
 pub struct Pl0 (
     #[tokenset] Pl0Token,

--- a/examples/lang_xml/src/syntax.rs
+++ b/examples/lang_xml/src/syntax.rs
@@ -1,6 +1,7 @@
 use copager::lang::{RuleSet, TokenSet, Lang};
 use copager::prelude::*;
 
+#[allow(dead_code)]
 #[derive(Lang)]
 pub struct Xml (
     #[tokenset] XmlToken,


### PR DESCRIPTION
とりあえず #[allow(dead_code)] を付加  
綺麗にできたらいいんだけど...